### PR TITLE
fix(install.ps1): add new package names

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ps1 text eol=crlf

--- a/install.ps1
+++ b/install.ps1
@@ -60,12 +60,12 @@ function Update-Config {
 $possiblePackageNames = @(
     # dev
     "FilesDev_ykqwq8d6ps0ag",
-    # classic
-    "Files_wvne1zexy08sa",
-    # classic preview
+    # Sideload
+    "Files_1y0xx7n9077q4",
+    # Sideload Preview
     "FilesPreview_1y0xx7n9077q4",
     # Microsoft Store
-    "FilesUWP_et10x9a9vyk8t"
+    "49306atecsolution.FilesUWP_et10x9a9vyk8t"
 )
 
 $locatedPaths = @()

--- a/install.ps1
+++ b/install.ps1
@@ -58,8 +58,10 @@ function Update-Config {
 
 # from https://files.community/docs/contributing/updates
 $possiblePackageNames = @(
-    # dev
+    # Dev
     "FilesDev_ykqwq8d6ps0ag",
+    # Classic
+    "Files_wvne1zexy08sa",
     # Sideload
     "Files_1y0xx7n9077q4",
     # Sideload Preview


### PR DESCRIPTION
This updates the list of possible package names in the script used for applying custom themes to the Files app. It now includes the correct package name for the Microsoft Store version, along with additional entries for dev, sideload, and sideload preview versions. This change ensures compatibility with the latest installation paths of the Files app, accommodating various installation sources including the Microsoft Store, development builds, and sideloaded versions.